### PR TITLE
WTH-9-WEETH: 출석 어드민 헤더 관리자 페이지 추가

### DIFF
--- a/src/components/Header/AdminButton.tsx
+++ b/src/components/Header/AdminButton.tsx
@@ -1,0 +1,21 @@
+import theme from '@/styles/theme';
+import styled from 'styled-components';
+
+const StyledText = styled.div`
+  color: ${theme.color.main};
+  font-size: 16px;
+  font-family: ${theme.font.semiBold};
+  cursor: pointer;
+`;
+
+const AdminButton = ({
+  text,
+  onClick,
+}: {
+  text: string;
+  onClick: () => void;
+}) => {
+  return <StyledText onClick={onClick}>{text}</StyledText>;
+};
+
+export default AdminButton;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -46,7 +46,8 @@ import SearchButton from '@/components/Header/SearchButton';
 import WritingButton from '@/components/Header/WritingButton';
 import PostButton from '@/components/Header/PostButton';
 import { pcResponsive } from '@/styles';
-import InfoButton from './InfoButton';
+import AdminButton from '@/components/Header/AdminButton';
+import InfoButton from '@/components/Header/InfoButton';
 // import EditButton from '@/components/Header/EditButton';
 
 interface HeaderProps {
@@ -61,6 +62,7 @@ interface HeaderProps {
     | 'WRITING'
     | 'POST'
     | 'INFO'
+    | 'ADMIN'
     | 'none';
   isComplete?: boolean;
   isAccessible: boolean;
@@ -118,6 +120,10 @@ const Header = ({
 
       {RightButtonType === 'POST' && onClickRightButton && isAccessible && (
         <PostButton onClick={onClickRightButton} text="게시하기" />
+      )}
+
+      {RightButtonType === 'ADMIN' && onClickRightButton && isAccessible && (
+        <AdminButton onClick={onClickRightButton} text="관리자" />
       )}
 
       {RightButtonType === 'MENU' && onClickRightButton && isAccessible && (

--- a/src/pages/attend/Attendance.tsx
+++ b/src/pages/attend/Attendance.tsx
@@ -1,7 +1,9 @@
+import useGetUserInfo from '@/api/useGetGlobaluserInfo';
 import AttendMain from '@/components/Attendance/AttendMain';
 import Header from '@/components/Header/Header';
 import useCustomBack from '@/hooks/useCustomBack';
 import { MOBILE } from '@/styles';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const Container = styled.div`
@@ -14,10 +16,20 @@ const Container = styled.div`
 
 const Attendance: React.FC = () => {
   useCustomBack('/home');
+  const { isAdmin } = useGetUserInfo();
+  const nav = useNavigate();
+
+  const handleRightButton = () => {
+    nav(`/admin/attendance`);
+  };
 
   return (
     <Container>
-      <Header RightButtonType="none" isAccessible>
+      <Header
+        isAccessible={isAdmin}
+        RightButtonType="ADMIN"
+        onClickRightButton={handleRightButton}
+      >
         출석
       </Header>
       <AttendMain />


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
출석 페이지에서 어드민일 경우 어드민 페이지로 바로 이동할 수 있는 컴포넌트를 추가하였습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="371" height="59" alt="image" src="https://github.com/user-attachments/assets/c9115a3e-a486-4c11-8ac7-9d5df6afebe1" />

<br>

## 4. 완료 사항
- `Header` 컴포넌트에서 어드민일 경우 type을 추가하여 분리해두었습니다.
<br>

## 5. 추가 사항

<br>
