### PR TITLE
WTH-13-WEETH : 페널티 UI 수정

### DIFF
--- a/src/components/Attendance/AttendMain.tsx
+++ b/src/components/Attendance/AttendMain.tsx
@@ -48,10 +48,11 @@ const AttendMain: React.FC = () => {
   } = useGetAttend(isAttend);
 
   useEffect(() => {
-    setHasPenalty(
-      penaltyInfo?.penaltyCount ? penaltyInfo.penaltyCount > 0 : false,
-    );
-  }, [penaltyInfo]);
+    const has =
+      (penaltyInfo?.penaltyCount ?? 0) > 0 ||
+      (penaltyInfo?.warningCount ?? 0) > 0;
+    setHasPenalty(has);
+  }, [penaltyInfo?.penaltyCount, penaltyInfo?.warningCount]);
 
   useEffect(() => {
     if (attendInfo?.status === 'ATTEND') {

--- a/src/components/Penalty/PenaltyItem.tsx
+++ b/src/components/Penalty/PenaltyItem.tsx
@@ -7,12 +7,12 @@ const PenaltyItem: React.FC<Penalty> = ({
   penaltyDescription,
   time,
 }) => {
-  const badgeType = penaltyType === 'PENALTY';
+  const badgeType = penaltyType === 'WARNING';
   return (
     <div>
       <S.Container>
         <S.PenaltyBedge $type={badgeType}>
-          {badgeType ? '페널티' : '경고'}
+          {badgeType ? '경고' : '페널티'}
         </S.PenaltyBedge>
         <S.ContentText>{penaltyDescription}</S.ContentText>
         <S.DateText>{formatDate(time)}</S.DateText>

--- a/src/styles/penalty/PenaltyItem.styled.ts
+++ b/src/styles/penalty/PenaltyItem.styled.ts
@@ -13,8 +13,8 @@ export const PenaltyBedge = styled.div<{ $type?: boolean }>`
   border-radius: 5px;
   text-align: center;
   font-size: 12px;
-  background-color: ${({ $type }) => ($type ? '#FF585840' : '#FFB20040')};
-  color: ${({ $type }) => ($type ? theme.color.negative : theme.color.caution)};
+  background-color: ${({ $type }) => ($type ? '#FFB20040' : '#FF585840')};
+  color: ${({ $type }) => ($type ? theme.color.caution : theme.color.negative)};
 `;
 export const ContentText = styled.text`
   font-size: 16px;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 경고만 있을 때 페널티 상세 페이지 진입 버튼이 뜨지 않았습니다.
- 경고 2회시 부여되는 페널티가 경고 뱃지로 떴습니다.

해당 버그를 해결하기 위해 코드 변경을 했습니다!

## 2. 어떤 위험이나 장애를 발견했나요?
- 기존 페널티 존재 여부 확인 코드에 경고 카운트를 추가하여 경고를 받을 시에도 페널티 진입 버튼이 보이도록 했습니다!
- 스타일링 분기 처리를 경고 기준으로 둬서 자동 페널티와 페널티는 페널티 스타일링으로 뜨도록 변경했습니다!

## 3. 완료 사항
위에 언급한 문제 해결 완료 햇습니다~!!

## 5. 추가 사항

<br>
