### PR TITLE
WTH-16-WEETH: 릴리즈 후 qa 사항 반영

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14142,6 +14142,7 @@
       "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-4.5.0.tgz",
       "integrity": "sha512-W+uoSpmVkSmNOGPSsDCWVW/DDAyv+9fap9AZXBvWiQqrboJ08j2vh0tFxTD/LjwqwAd3yYSVJgm54S/1GhbdnA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^5.2.0",
         "@svgr/core": "^8.1.0",

--- a/src/components/Board/PartBoard.tsx
+++ b/src/components/Board/PartBoard.tsx
@@ -1,47 +1,50 @@
 import * as S from '@/styles/board/Board.styled';
 import { useNavigate } from 'react-router-dom';
-import PressedD from '@/assets/images/ic_board_D.svg';
-import PressedBE from '@/assets/images/ic_board_BE.svg';
-import PressedFE from '@/assets/images/ic_board_FE.svg';
-import PressedPM from '@/assets/images/ic_board_PM.svg';
-import DefaultD from '@/assets/images/ic_default_board_D.svg';
-import DefaultBE from '@/assets/images/ic_default_board_BE.svg';
-import DefaultFE from '@/assets/images/ic_default_board_FE.svg';
-import DefaultPM from '@/assets/images/ic_default_board_PM.svg';
+import PressedD from '@/assets/images/ic_board_D.svg?react';
+import PressedBE from '@/assets/images/ic_board_BE.svg?react';
+import PressedFE from '@/assets/images/ic_board_FE.svg?react';
+import PressedPM from '@/assets/images/ic_board_PM.svg?react';
+import DefaultD from '@/assets/images/ic_default_board_D.svg?react';
+import DefaultBE from '@/assets/images/ic_default_board_BE.svg?react';
+import DefaultFE from '@/assets/images/ic_default_board_FE.svg?react';
+import DefaultPM from '@/assets/images/ic_default_board_PM.svg?react';
 import { useRef, useState } from 'react';
+import type { ComponentType, SVGProps } from 'react';
 import { useDraggable } from '@/hooks/useDraggable';
+
+type SvgCmp = ComponentType<SVGProps<SVGSVGElement>>;
 
 type PartItem = {
   key: '' | 'FE' | 'BE' | 'D' | 'PM';
   url: 'ALL' | 'FE' | 'BE' | 'D' | 'PM';
-  defaultImg: string;
-  pressedImg: string;
+  defaultIcon: SvgCmp;
+  pressedIcon: SvgCmp;
 };
 
 const parts: PartItem[] = [
   {
     key: 'FE',
     url: 'FE',
-    defaultImg: DefaultFE,
-    pressedImg: PressedFE,
+    defaultIcon: DefaultFE,
+    pressedIcon: PressedFE,
   },
   {
     key: 'BE',
     url: 'BE',
-    defaultImg: DefaultBE,
-    pressedImg: PressedBE,
+    defaultIcon: DefaultBE,
+    pressedIcon: PressedBE,
   },
   {
     key: 'D',
     url: 'D',
-    defaultImg: DefaultD,
-    pressedImg: PressedD,
+    defaultIcon: DefaultD,
+    pressedIcon: PressedD,
   },
   {
     key: 'PM',
     url: 'PM',
-    defaultImg: DefaultPM,
-    pressedImg: PressedPM,
+    defaultIcon: DefaultPM,
+    pressedIcon: PressedPM,
   },
 ];
 
@@ -74,7 +77,7 @@ const PartBoard = () => {
         <S.PartList>
           {parts.map((part) => {
             const isPressed = pressedKey === part.key;
-            const imgSrc = isPressed ? part.pressedImg : part.defaultImg;
+            const Icon = isPressed ? part.pressedIcon : part.defaultIcon;
 
             return (
               <S.PartItem
@@ -91,7 +94,11 @@ const PartBoard = () => {
                   }
                 }}
               >
-                <S.PartImage src={imgSrc} alt={part.key} />
+                <Icon
+                  width={76}
+                  height={76}
+                  style={{ pointerEvents: 'none' }}
+                />
                 <S.PartLabel>{part.key}</S.PartLabel>
               </S.PartItem>
             );

--- a/src/components/Board/StudyBoardSearch.tsx
+++ b/src/components/Board/StudyBoardSearch.tsx
@@ -41,7 +41,6 @@ const Search = styled.div`
   justify-content: space-between;
   border: 1px solid ${theme.color.gray[18]};
   border-radius: 0.25rem;
-  gap: 10px;
   box-sizing: border-box;
   transition: border 0.2s;
   padding: 13px 12px;
@@ -49,6 +48,11 @@ const Search = styled.div`
   &:focus-within {
     border: 1px solid ${theme.color.gray[65]};
   }
+`;
+
+const SearchRightButton = styled.div`
+  display: flex;
+  align-items: center;
 `;
 
 export const SearchInput = styled.input`
@@ -59,6 +63,7 @@ export const SearchInput = styled.input`
   color: #fff;
   padding: 0;
   justify-content: center;
+  width: 100%;
 
   &::placeholder {
     font-size: 1rem;
@@ -67,8 +72,7 @@ export const SearchInput = styled.input`
 `;
 
 const Divider = styled.img`
-  margin: 0 0.75rem;
-  padding: 1px 0px 0px 0px;
+  margin: 0 12px;
 `;
 
 const SearchButton = styled.img<{ disabled?: boolean }>`
@@ -147,7 +151,7 @@ const StudyBoardSearch = ({
             if (e.key === 'Enter') handleSearch();
           }}
         />
-        <div>
+        <SearchRightButton>
           {keyword && (
             <SearchButton
               src={Delete}
@@ -162,7 +166,7 @@ const StudyBoardSearch = ({
             onClick={handleSearch}
             disabled={!keyword}
           />
-        </div>
+        </SearchRightButton>
       </Search>
     </Container>
   );

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -74,8 +74,10 @@ const HeaderWrapper = styled.div`
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  padding: 25px 25px 10px 25px;
+  padding: 25px 0 10px 0;
   box-sizing: border-box;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 
   ${pcResponsive}
   position: sticky;
@@ -84,9 +86,31 @@ const HeaderWrapper = styled.div`
   background-color: ${theme.color.gray[12]};
 `;
 
+const HeaderLeft = styled.div`
+  display: flex;
+  align-items: center;
+  justify-self: start;
+  padding: 0 25px;
+`;
+
+const HeaderCenter = styled.div`
+  display: flex;
+  align-items: center;
+  justify-self: center;
+  text-align: center;
+`;
+
+const HeaderRight = styled.div`
+  display: flex;
+  align-items: center;
+  justify-self: end;
+  padding: 0 15px;
+`;
+
 const Title = styled.div`
   font-size: 18px;
   font-family: ${theme.font.semiBold};
+  white-space: nowrap;
 `;
 
 const None = styled.div`
@@ -103,49 +127,57 @@ const Header = ({
 }: HeaderProps) => {
   return (
     <HeaderWrapper>
-      <LeftButton isWaiting={isWaiting} />
-      <Title>{children}</Title>
+      <HeaderLeft>
+        <LeftButton isWaiting={isWaiting} />
+      </HeaderLeft>
+      <HeaderCenter>
+        <Title>{children}</Title>
+      </HeaderCenter>
 
-      {RightButtonType === 'TEXT' && onClickRightButton && (
-        <TextButton
-          onClick={onClickRightButton}
-          text="완료"
-          isComplete={isComplete}
-        />
-      )}
+      <HeaderRight>
+        {RightButtonType === 'TEXT' && onClickRightButton && (
+          <TextButton
+            onClick={onClickRightButton}
+            text="완료"
+            isComplete={isComplete}
+          />
+        )}
 
-      {RightButtonType === 'WRITING' && isAccessible && onClickRightButton && (
-        <WritingButton onClick={onClickRightButton} text="글쓰기" />
-      )}
+        {RightButtonType === 'WRITING' &&
+          isAccessible &&
+          onClickRightButton && (
+            <WritingButton onClick={onClickRightButton} text="글쓰기" />
+          )}
 
-      {RightButtonType === 'POST' && onClickRightButton && isAccessible && (
-        <PostButton onClick={onClickRightButton} text="게시하기" />
-      )}
+        {RightButtonType === 'POST' && onClickRightButton && isAccessible && (
+          <PostButton onClick={onClickRightButton} text="게시하기" />
+        )}
 
-      {RightButtonType === 'ADMIN' && onClickRightButton && isAccessible && (
-        <AdminButton onClick={onClickRightButton} text="관리자" />
-      )}
+        {RightButtonType === 'ADMIN' && onClickRightButton && isAccessible && (
+          <AdminButton onClick={onClickRightButton} text="관리자" />
+        )}
 
-      {RightButtonType === 'MENU' && onClickRightButton && isAccessible && (
-        <MenuButton onClick={onClickRightButton} />
-      )}
+        {RightButtonType === 'MENU' && onClickRightButton && isAccessible && (
+          <MenuButton onClick={onClickRightButton} />
+        )}
 
-      {RightButtonType === 'PLUS' && isAccessible && <PlusButton />}
+        {RightButtonType === 'PLUS' && isAccessible && <PlusButton />}
 
-      {/* {RightButtonType === 'EDIT' && onClickRightButton && (
+        {/* {RightButtonType === 'EDIT' && onClickRightButton && (
         <EditButton onClick={onClickRightButton} />
       )} */}
 
-      {RightButtonType === 'SEARCH' && onClickRightButton && isAccessible && (
-        <SearchButton onClick={onClickRightButton} />
-      )}
+        {RightButtonType === 'SEARCH' && onClickRightButton && isAccessible && (
+          <SearchButton onClick={onClickRightButton} />
+        )}
 
-      {RightButtonType === 'INFO' && onClickRightButton && isAccessible && (
-        <InfoButton onClick={onClickRightButton} />
-      )}
+        {RightButtonType === 'INFO' && onClickRightButton && isAccessible && (
+          <InfoButton onClick={onClickRightButton} />
+        )}
 
-      {RightButtonType !== 'none' && !isAccessible && <None />}
-      {RightButtonType === 'none' && <None />}
+        {RightButtonType !== 'none' && !isAccessible && <None />}
+        {RightButtonType === 'none' && <None />}
+      </HeaderRight>
     </HeaderWrapper>
   );
 };

--- a/src/components/home/HomeFooter.tsx
+++ b/src/components/home/HomeFooter.tsx
@@ -45,7 +45,7 @@ const HomeFooter: React.FC = () => {
           홈페이지
         </S.GridItem>
         <S.GridItem
-          href="https://www.instagram.com/leets.official/"
+          href="https://www.instagram.com/leets_official?igsh=bGI4bTJmMjB5OHk3"
           target="_blank"
         >
           <S.ImgContainer>


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 릴리즈 후 QA사항을 반영하였습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="254" height="68" alt="image" src="https://github.com/user-attachments/assets/04a51eea-3044-4fd6-80ad-55f1bd1d914e" />

<br>

## 4. 완료 사항
- 검색 툴 바 모바일에서 깨지는 UI 수정
- 검색 툴바 입력시 좌측만 클릭이 되고 가운데부터 우측은 클릭 안되는 문제 해결
- 헤더 3등분 후 정렬되도록 수정 (전에는 오른쪽 컴포넌트의 크기에 따라 `justify-between`으로 인해 중간 단어 정렬이 안됐었음)
- 파트게시판 `img`태그로 불러와서 화질이 깨졌던 것 같아서 `svg?react`로 컴포넌트로 불러오는 식으로 수정해두었습니다.
<br>

## 5. 추가 사항

<br>
