### PR TITLE
WTH-29-WEETH: 대댓글 오른쪽 패딩 추가 

### DIFF
--- a/src/components/Board/ReplyComment.tsx
+++ b/src/components/Board/ReplyComment.tsx
@@ -86,13 +86,21 @@ const ReplyComment = ({
     <S.ReplyCommentContainer>
       <S.ReplyArrow src={ReplyArrowImage} alt="답댓글 화살표" />
       <S.ReplyContentContainer>
-        <S.NameText>
-          <S.PositionIcon
-            src={setPositionIcon(role, position)}
-            alt="포지션 아이콘"
-          />
-          {name}
-        </S.NameText>
+        <S.ReplyHeaderContainer>
+          <S.NameText>
+            <S.PositionIcon
+              src={setPositionIcon(role, position)}
+              alt="포지션 아이콘"
+            />
+            {name}
+          </S.NameText>
+          {isMyComment && (
+            <S.ReplyImageButton onClick={onClickMenu}>
+              <img src={MenuImage} alt="메뉴 버튼" />
+            </S.ReplyImageButton>
+          )}
+        </S.ReplyHeaderContainer>
+
         <S.ContentContainer>
           <S.ContentText>{parse(convertLinksInText(content))}</S.ContentText>
           {fileUrls.length > 0 && (
@@ -110,11 +118,6 @@ const ReplyComment = ({
           )}
         </S.ContentContainer>
         <S.DateText>{formattedTime}</S.DateText>
-        {isMyComment && (
-          <S.ReplyImageButton onClick={onClickMenu}>
-            <img src={MenuImage} alt="메뉴 버튼" />
-          </S.ReplyImageButton>
-        )}
       </S.ReplyContentContainer>
       {isModalOpen && (
         <SelectModal

--- a/src/styles/board/Comment.styled.ts
+++ b/src/styles/board/Comment.styled.ts
@@ -56,7 +56,6 @@ export const PositionIcon = styled.img`
 export const ContentText = styled.div`
   font-size: 1rem;
   line-height: 1.1931rem;
-
   a {
     color: ${theme.color.main};
     text-decoration: none;
@@ -104,11 +103,17 @@ export const ReplyContentContainer = styled.div`
   flex: 1;
   background-color: ${theme.color.gray[18]};
   border-radius: 0.5rem;
-  padding: 10px 0 10px 10px;
+  padding: 10px 10px 10px 10px;
   display: flex;
   flex-direction: column;
   position: relative;
   gap: 5px;
+`;
+
+export const ReplyHeaderContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
 `;
 
 export const ReplyImageButton = styled.button`
@@ -116,7 +121,4 @@ export const ReplyImageButton = styled.button`
   border: none;
   padding: 0;
   cursor: pointer;
-  position: absolute;
-  top: 0.625rem;
-  right: 0.625rem;
 `;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
대댓글 우측 영역 패딩을 추가하기 위해 변경했습니다!

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="382" height="262" alt="image" src="https://github.com/user-attachments/assets/c9bc2880-d984-4db3-b0a6-3026b1ad3daa" />

## 4. 완료 사항
- 대댓글 우측 패딩 추가
- 대댓글 헤더 구조 변경

## 5. 추가 사항
대댓글에 더보기 버튼이 앱솔루트로 되어 잇어서 간격이 좀 틀어지더라구욥.. 그래서 헤더 컨테이너에 넣고 앱솔루트 풀엇습니다!
