### PR TITLE
[Refactor] WTH-20-weeth: v.3.0.2 qa 사항 반영

### DIFF
--- a/src/api/uploadFiles.tsx
+++ b/src/api/uploadFiles.tsx
@@ -3,8 +3,6 @@ import axios from 'axios';
 import qs from 'qs';
 
 const BASE_URL = import.meta.env.VITE_API_URL;
-const accessToken = localStorage.getItem('accessToken');
-const refreshToken = localStorage.getItem('refreshToken');
 
 // 파일을 Presigned URL로 업로드하는 함수
 const uploadFileToS3 = async (presignedUrl: string, file: File) => {
@@ -28,6 +26,8 @@ export const getFileUrl = async (fileNames: string[], files: File[]) => {
     console.log('No files to upload, skipping the request.');
     return [];
   }
+  const accessToken = localStorage.getItem('accessToken');
+  const refreshToken = localStorage.getItem('refreshToken');
 
   // 1. 서버에서 Presigned URL 요청
   const response = await axios.get(`${BASE_URL}/files/`, {

--- a/src/api/useGetCardinals.tsx
+++ b/src/api/useGetCardinals.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import api from '@/api/api';
 
 export const getAllCardinals = async () => {
@@ -8,7 +8,7 @@ export const getAllCardinals = async () => {
 export const useGetAllCardinals = () => {
   const [allCardinals, setAllCardinals] = useState<
     {
-      status: string; // 기수 상태값 추가 ( IN_PROGRESS 이면 현재 기수 )
+      status: string;
       id: number;
       cardinalNumber: number;
     }[]
@@ -33,7 +33,11 @@ export const useGetAllCardinals = () => {
     fetchUsers();
   }, []);
 
-  return { allCardinals, error };
+  const currentCardinal = useMemo<number | null>(() => {
+    const cur = allCardinals.find((c) => c.status === 'IN_PROGRESS');
+    return cur?.cardinalNumber ?? null;
+  }, [allCardinals]);
+  return { allCardinals, currentCardinal, error };
 };
 
 export default useGetAllCardinals;

--- a/src/components/Board/Comment.tsx
+++ b/src/components/Board/Comment.tsx
@@ -106,7 +106,7 @@ const Comment = ({
         <S.ContentContainer>
           <S.ContentText>{parse(convertLinksInText(content))}</S.ContentText>
           {fileUrls.length > 0 && (
-            <S.ContentText>
+            <S.FileListContainer>
               {fileUrls.map((file) => (
                 <PostFile
                   key={file.fileId}
@@ -116,7 +116,7 @@ const Comment = ({
                   isComment
                 />
               ))}
-            </S.ContentText>
+            </S.FileListContainer>
           )}
         </S.ContentContainer>
         <S.DateText>{formattedTime}</S.DateText>

--- a/src/components/Board/ContentPost.tsx
+++ b/src/components/Board/ContentPost.tsx
@@ -32,7 +32,7 @@ const ContentWrapper = styled.textarea`
 
   @media (min-width: ${PC}) {
     max-width: ${PC};
-    height: 705px;
+    height: calc(100vh - 400px);
   }
 
   &::placeholder {

--- a/src/components/Board/ReplyComment.tsx
+++ b/src/components/Board/ReplyComment.tsx
@@ -96,7 +96,7 @@ const ReplyComment = ({
         <S.ContentContainer>
           <S.ContentText>{parse(convertLinksInText(content))}</S.ContentText>
           {fileUrls.length > 0 && (
-            <S.ContentText>
+            <S.FileListContainer>
               {fileUrls.map((file) => (
                 <PostFile
                   key={file.fileId}
@@ -106,7 +106,7 @@ const ReplyComment = ({
                   isComment
                 />
               ))}
-            </S.ContentText>
+            </S.FileListContainer>
           )}
         </S.ContentContainer>
         <S.DateText>{formattedTime}</S.DateText>

--- a/src/components/Event/EventEditor.tsx
+++ b/src/components/Event/EventEditor.tsx
@@ -26,6 +26,7 @@ import {
   toastSuccess,
 } from '@/components/common/ToastMessage';
 import SelectModal from '@/components/Modal/SelectModal';
+import useGetAllCardinals from '@/api/useGetCardinals';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -52,6 +53,7 @@ const EventEditor = () => {
   const path = pathArray[3];
 
   const { id } = useParams();
+  const { currentCardinal } = useGetAllCardinals();
   const { data: eventDetailData, loading, error } = useGetEventInfo(type, id);
   const isEditMode = Boolean(id);
   const navigate = useNavigate();
@@ -67,8 +69,7 @@ const EventEditor = () => {
 
   const [eventRequest, setEventRequest] = useState<EventRequestType>({
     title: '',
-    // TODO: (refactor) 서버로부터 받은 기수값을 이용하여 초기값 설정하는 로직 추가
-    cardinal: 5,
+    cardinal: currentCardinal ?? 0,
     type: 'EVENT',
     start: '',
     end: '',
@@ -89,6 +90,12 @@ const EventEditor = () => {
       [key]: value,
     }));
   };
+
+  useEffect(() => {
+    if (typeof currentCardinal === 'number') {
+      setEventRequest((prev) => ({ ...prev, cardinal: currentCardinal }));
+    }
+  }, [currentCardinal]);
 
   useEffect(() => {
     if (startDate && startTime) {

--- a/src/pages/board/education/EduPost.tsx
+++ b/src/pages/board/education/EduPost.tsx
@@ -4,6 +4,7 @@ import postBoardNotice from '@/api/postBoardNotice';
 import { PostRequestType } from '@/types/PostRequestType';
 import EduWrite from '@/components/Board/EduWrite';
 import { PartTypes } from '@/types/part';
+import { toastError } from '@/components/common/ToastMessage';
 
 type RealPart = Exclude<PartTypes, '' | 'ALL'>;
 const REAL_PARTS: RealPart[] = ['FE', 'BE', 'D', 'PM'];
@@ -26,6 +27,19 @@ const EduPost = () => {
   const [files, setFiles] = useState<File[]>([]);
 
   const onSave = async () => {
+    if (!title) {
+      toastError('제목을 입력해주세요.');
+      return;
+    }
+    if (!content) {
+      toastError('내용을 입력해주세요.');
+      return;
+    }
+    if (!selectedCardinal) {
+      toastError('기수를 선택해주세요.');
+      return;
+    }
+
     const partsToSend: PartTypes[] =
       selectedPart.length === REAL_PARTS.length || selectedPart.length === 0
         ? ['ALL']

--- a/src/pages/board/education/EducationBoard.tsx
+++ b/src/pages/board/education/EducationBoard.tsx
@@ -11,18 +11,21 @@ import useGetEducationBoard from '@/api/useGetEducationBoard';
 import Loading from '@/components/common/Loading';
 import { SearchContent } from '@/types/search';
 import useGetUserInfo from '@/api/useGetGlobaluserInfo';
+import useCustomBack from '@/hooks/useCustomBack';
 
 type Part = 'FE' | 'BE' | 'D' | 'PM' | 'ALL';
 
 const EducationBoard = () => {
+  useCustomBack('/board');
+
   const { isAdmin } = useGetUserInfo();
+
+  const [searchLoading, setSearchLoading] = useState(false);
 
   const [selectedCardinal, setSelectedCardinal] = useState<number | null>(null);
 
   const [searchMode, setSearchMode] = useState(false);
   const [searchResults, setSearchResults] = useState<SearchContent[]>([]);
-  const [searchLoading, setSearchLoading] = useState(false);
-
   const navigate = useNavigate();
   const observerRef = useRef<HTMLDivElement | null>(null);
   const { part: partParam } = useParams<{ part: Part }>();
@@ -64,6 +67,7 @@ const EducationBoard = () => {
   const handleSearchDone = (result: SearchContent[]) => {
     setSearchMode(true);
     setSearchResults(result);
+    setSelectedCardinal(null);
   };
   const handleSearchClear = () => {
     setSearchMode(false);

--- a/src/pages/board/notices/BoardNotice.tsx
+++ b/src/pages/board/notices/BoardNotice.tsx
@@ -10,6 +10,7 @@ import Loading from '@/components/common/Loading';
 import { BoardContent } from '@/pages/Board';
 import { SearchContent } from '@/types/search';
 import useGetUserInfo from '@/api/useGetGlobaluserInfo';
+import useCustomBack from '@/hooks/useCustomBack';
 
 interface Content {
   id: number;
@@ -27,6 +28,8 @@ interface Content {
 }
 
 const BoardNotice = () => {
+  useCustomBack('/board');
+
   const { isAdmin } = useGetUserInfo();
 
   const navigate = useNavigate();

--- a/src/pages/board/part/PartBoard.tsx
+++ b/src/pages/board/part/PartBoard.tsx
@@ -14,6 +14,7 @@ import { BoardContent } from '@/pages/Board';
 import Loading from '@/components/common/Loading';
 import { SearchContent } from '@/types/search';
 import useGetUserInfo from '@/api/useGetUserInfo';
+import useCustomBack from '@/hooks/useCustomBack';
 
 type CatEnum = 'StudyLog' | 'Article';
 type CatSlug = 'study' | 'article';
@@ -25,6 +26,8 @@ const enumToSlug = (c: CatEnum): CatSlug =>
 type Part = 'FE' | 'BE' | 'D' | 'PM' | 'ALL';
 
 const PartBoard = () => {
+  useCustomBack('/board');
+
   const { userInfo } = useGetUserInfo();
 
   const [selectedCardinal, setSelectedCardinal] = useState<number | null>(null);
@@ -106,11 +109,14 @@ const PartBoard = () => {
     });
 
   const posts = data?.pages.flatMap((page) => page.content) ?? [];
-
   const handleSearchDone = (result: SearchContent[]) => {
     setSearchMode(true);
     setSearchResults(result);
+    setSelectedCardinal(null);
+    setSelectedWeek(null);
+    setSelectedTag(null);
   };
+
   const handleSearchClear = () => {
     setSearchMode(false);
     setSearchResults([]);

--- a/src/pages/board/part/PartPost.tsx
+++ b/src/pages/board/part/PartPost.tsx
@@ -30,6 +30,15 @@ const PartPost = () => {
   const [files, setFiles] = useState<File[]>([]);
 
   const onSave = async () => {
+    if (!title) {
+      toastError('제목을 입력해주세요.');
+      return;
+    }
+    if (!content) {
+      toastError('내용을 입력해주세요.');
+      return;
+    }
+
     if (category === 'StudyLog') {
       if (!selectedCardinal) {
         toastError('기수를 선택해주세요.');

--- a/src/styles/board/Comment.styled.ts
+++ b/src/styles/board/Comment.styled.ts
@@ -67,6 +67,12 @@ export const ContentText = styled.div`
   }
 `;
 
+export const FileListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
 export const DateText = styled.div`
   color: ${theme.color.gray[65]};
   font-size: 0.75rem;

--- a/src/styles/board/Markdown.styled.ts
+++ b/src/styles/board/Markdown.styled.ts
@@ -83,7 +83,7 @@ export const PreviewWrapper = styled.div`
 
   @media (min-width: ${PC}) {
     max-width: ${PC};
-    height: 705px;
+    height: calc(100vh - 400px);
   }
 
   img,


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
v.3.0.2 qa 사항을 반영하기 위함.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항
- 게시판에서 뒤로 가기 수정
- 게시판 검색 시 관련 드롭다운 전체 초기화
- 마크다운 에디터 영역 축소
- 댓글 및 대댓글에서 여러 파일 간의 gap 추가
- 일정 추가에서 현재 기수값 api 통해서 받아오도록 수정
- 제목 및 내용 없을 경우 에러 처리
- 이미지 업로드 관련 토큰 상단 선언 제거 및 사용 시 필요할때 선언하도록 수정
<br>

## 5. 추가 사항

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 이벤트 작성 시 진행 중인 기수를 자동 선택
  - 게시판 화면에 커스텀 뒤로가기 동작 적용
  - 교육 게시판 검색 로딩 상태 표시

- 개선
  - 검색 완료 시 선택된 기수/필터 초기화로 결과 정리
  - 공지/파트/교육 게시판에서 검색 후 목록 상태 일관성 향상

- 버그 수정
  - 제목/내용/기수 미입력 시 저장을 차단하고 오류 토스트 안내

- 스타일
  - 에디터/미리보기 높이를 화면 높이에 맞춰 동적 계산
  - 댓글/대댓글의 파일 목록 레이아웃 정돈

- 기타
  - 파일 업로드 토큰 조회 시점 조정 (동작 영향 없음)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->